### PR TITLE
update nb initial parameters

### DIFF
--- a/spateo/segmentation/icell.py
+++ b/spateo/segmentation/icell.py
@@ -384,7 +384,7 @@ def score_and_mask_pixels(
         threshold = filters.threshold_multiotsu(scores)[1] if "bp" in method else filters.threshold_otsu(scores)
 
     lm.main_info(f"Applying threshold {threshold}.")
-    mk = mk or k
+    mk = mk or (k + 2 if any(m in method for m in ("em", "vi")) else max(k - 2, 3))
     mask = utils.apply_threshold(scores, mk, threshold)
     if certain_layer:
         mask += certain_mask

--- a/spateo/segmentation/icell.py
+++ b/spateo/segmentation/icell.py
@@ -384,7 +384,7 @@ def score_and_mask_pixels(
         threshold = filters.threshold_multiotsu(scores)[1] if "bp" in method else filters.threshold_otsu(scores)
 
     lm.main_info(f"Applying threshold {threshold}.")
-    mk = mk or (k + 2 if any(m in method for m in ("em", "vi")) else 3)
+    mk = mk or k
     mask = utils.apply_threshold(scores, mk, threshold)
     if certain_layer:
         mask += certain_mask

--- a/spateo/segmentation/icell.py
+++ b/spateo/segmentation/icell.py
@@ -175,7 +175,7 @@ def _initial_nb_params(
         # Negative binomial distribution requires variance > mean
         if var[0] <= mu[0]:
             lm.main_warning(
-                f"Estimated variance of background ({var[0]:.2f}) is less than the mean ({mu[0]:.2f}). "
+                f"Estimated variance of background ({var[0]:.2e}) is less than the mean ({mu[0]:.2e}). "
                 "Initial variance will be arbitrarily set to 1.1x of the mean. "
                 "This is usually due to extreme sparsity. Please consider increasing `k` or using "
                 "the zero-inflated distribution."
@@ -183,7 +183,7 @@ def _initial_nb_params(
             var[0] = mu[0] * 1.1
         if var[1] <= mu[1]:
             lm.main_warning(
-                f"Estimated variance of foreground ({var[1]:.2f}) is less than the mean ({mu[1]:.2f}). "
+                f"Estimated variance of foreground ({var[1]:.2e}) is less than the mean ({mu[1]:.2e}). "
                 "Initial variance will be arbitrarily set to 1.1x of the mean. "
                 "This is usually due to extreme sparsity. Please consider increasing `k` or using "
                 "the zero-inflated distribution."

--- a/spateo/segmentation/icell.py
+++ b/spateo/segmentation/icell.py
@@ -165,11 +165,17 @@ def _initial_nb_params(
         mask = _samples > threshold
         background_values = _samples[~mask]
         foreground_values = _samples[mask]
-        params[label] = dict(
-            w=tuple(np.array([_samples.size - mask.sum(), mask.sum()]) / _samples.size),
-            mu=(background_values.mean(), foreground_values.mean()),
-            var=(background_values.var(), foreground_values.var()),
-        )
+        w = tuple(np.array([_samples.size - mask.sum(), mask.sum()]) / _samples.size)
+        mu = (background_values.mean(), foreground_values.mean())
+        var0 = background_values.var()
+        var1 = foreground_values.var()
+        # Negative binomial distribution requires variance > mean
+        if var0 <= mu[0]:
+            var0 = mu[0] * 1.1
+        if var1 <= mu[1]:
+            var1 = mu[1] * 1.1
+        var = (var0, var1)
+        params[label] = dict(w=w, mu=mu, var=var)
     return params[0] if bins is None else params
 
 

--- a/spateo/segmentation/vi.py
+++ b/spateo/segmentation/vi.py
@@ -105,7 +105,7 @@ class NegativeBinomialMixture(PyroModule):
 
         # Is there a better way to initialize the dropout param?
         if self.zero_inflated:
-            self.z = PyroParam(torch.randn(self.n))
+            self.z = PyroParam(probs_to_logits(torch.zeros(self.n).float(), is_binary=True))
 
     def optimizer(self):
         if self.__optimizer is None:


### PR DESCRIPTION
When the UMIs are extremely sparse, sometimes variance <= mean (which is impossible for NB distribution).
In this case, print a warning. Don't think there's much we can do to fix this.