### PR TITLE
Set `sphinxext-opengraph` to 0.8.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,7 @@ sphinx_copybutton
 sphinx-gallery<0.10.1
 sphinx-remove-toctrees
 sphinx-design
-sphinxext-opengraph
+sphinxext-opengraph==0.8.2
 sphinx-autoapi
 gitpython
 myst-parser


### PR DESCRIPTION
Set `sphinxext-opengraph` to an earlier version because 0.9.1 causes a bug when building (probably related to `matplotlib` version as well).