### PR TITLE
Fixed some bugs in CCI code

### DIFF
--- a/spateo/tools/CCI_effects_modeling/MuSIC.py
+++ b/spateo/tools/CCI_effects_modeling/MuSIC.py
@@ -293,6 +293,8 @@ class MuSIC:
             for file in file_list:
                 if not "predictions" in file:
                     check = pd.read_csv(os.path.join(parent_dir, file), index_col=0)
+                    if isinstance(check.index[0], int):
+                        check.index = check.index.astype(str)
                     if any([name not in check.index for name in self.sample_names]):
                         self.map_new_cells()
                     break
@@ -635,6 +637,10 @@ class MuSIC:
                     self.adata.X.data += 1
                 else:
                     self.adata.X += 1
+            else:
+                self.adata.layers[
+                    "original_counts"
+                ] = self.adata.X.copy()  # add this since gaussian model may also need this in downstream model
 
             if "downstream" in self.mod_type:
                 # For finding upstream associations with ligand
@@ -2738,7 +2744,10 @@ class MuSIC:
                 pred_y = np.dot(X[i], betas)
 
             residual = y[i] - pred_y
-            diagnostic = residual
+            if isinstance(residual, np.ndarray) or isinstance(residual, list):
+                diagnostic = residual[0]
+            else:
+                diagnostic = residual
             # Reshape coefficients if necessary:
             betas = betas.flatten()
             # Effect of deleting sample i from the dataset on the estimated predicted value at sample i:
@@ -3447,7 +3456,11 @@ class MuSIC:
                     else:
                         # Compute the Pearson correlation coefficient for the subset
                         if len(X_subset) > 1:  # Ensure there are at least 2 data points to compute correlation
-                            correlation = scipy.stats.pearsonr(X_subset, y_subset)[0]
+                            try:
+                                correlation = scipy.stats.pearsonr(X_subset, y_subset)[0]
+                            except ValueError:
+                                self.logger.info("Some values are missing in the data. Skipping.")
+                                correlation = np.nan
                         else:
                             correlation = np.nan  # Not enough data points to compute correlation
 
@@ -3831,9 +3844,13 @@ class MuSIC:
                         # is unknown whether the ligand/receptor (the half of the interacting pair that is missing) is
                         # present in the neighborhood of these cells:
                         if self.mod_type in ["receptor", "ligand", "downstream"]:
-                            mask_matrix = (self.adata[betas.index, target].X != 0).toarray().astype(int)
+                            if isinstance(self.adata[betas.index, target].X, np.ndarray):
+                                mask_matrix = (self.adata[betas.index, target].X != 0).astype(int)
+                            else:
+                                mask_matrix = (self.adata[betas.index, target].X != 0).toarray().astype(int)
                             betas *= mask_matrix
                             standard_errors *= mask_matrix
+
                         mask_df = (self.X_df.loc[betas.index] != 0).astype(int)
                         mask_df = mask_df.loc[:, [g for g in mask_df.columns if g in feat_sub]]
                         for col in betas.columns:

--- a/spateo/tools/CCI_effects_modeling/MuSIC_downstream.py
+++ b/spateo/tools/CCI_effects_modeling/MuSIC_downstream.py
@@ -2002,7 +2002,7 @@ class MuSIC_Interpreter(MuSIC):
         else:
             rounding_base = 1000
 
-        pos = pos.round(-int(pd.np.log10(rounding_base)))
+        pos = pos.round(-int(np.log10(rounding_base)))
 
         # If position array is numerical, there may not be an exact match- convert the data type to integer:
         if pos.dtype == float:
@@ -2206,10 +2206,14 @@ class MuSIC_Interpreter(MuSIC):
                     consecutive_counts[feature] += 1
                     if consecutive_counts[feature] >= int(window_size * 1.67):
                         feats_of_interest.add(feature)
-                for feature in combinations:
-                    if feature not in top_combinations[pos]:
-                        consecutive_counts[feature] = 0
+                # I am not sure what this is for. It will remove genes encountered before, and consecutive_counts is no longer used here after.
+                # for feature in combinations:
+                #     if feature not in top_combinations[pos]:
+                #         consecutive_counts[feature] = 0
 
+            feats_of_interest = list(
+                feats_of_interest
+            )  # fix for set subscription, set subscription is no longer allowed
             to_plot = all_fc_coord_sorted[feats_of_interest]
             if to_plot.index.is_numeric():
                 # Minmax scale to normalize positional context:
@@ -3944,7 +3948,10 @@ class MuSIC_Interpreter(MuSIC):
 
                 if to_plot == "mean":
                     mean_effects = []
-                    coef_target = self.coeffs[target].loc[adata.obs_names]
+                    # coef_target = self.coeffs[target].loc[adata.obs_names]
+                    coef_target = self.coeffs[target].loc[
+                        cell_in_ct.obs_names
+                    ]  # This should be cell_in_ct, since it's cell type specific effect, and not the entire adata object
                     coef_target = coef_target[[c for c in coef_target.columns if "intercept" not in c]]
 
                     if effect_threshold is None:
@@ -6901,7 +6908,10 @@ class MuSIC_Interpreter(MuSIC):
                 if scipy.sparse.issparse(adata.X):
                     nnz_counts = np.array(adata[:, all_TFs].X.getnnz(axis=0)).flatten()
                 else:
-                    nnz_counts = np.array(adata[:, all_TFs].X.getnnz(axis=0)).flatten()
+                    # nnz_counts = np.array(adata[:, all_TFs].X.getnnz(axis=0)).flatten()
+                    nnz_counts = np.count_nonzero(
+                        adata[:, all_TFs].X, axis=0
+                    ).flatten()  # np.ndarray have no getnnz attributes
                 all_TFs = [tf for tf, nnz in zip(all_TFs, nnz_counts) if nnz >= n_cells_threshold]
                 if custom_tfs is not None:
                     all_TFs.extend(custom_tfs)
@@ -6912,7 +6922,7 @@ class MuSIC_Interpreter(MuSIC):
                 if scipy.sparse.issparse(adata.X):
                     nnz_counts = np.array(adata[:, secondary_TFs].X.getnnz(axis=0)).flatten()
                 else:
-                    nnz_counts = np.array(adata[:, secondary_TFs].X.getnnz(axis=0)).flatten()
+                    nnz_counts = np.count_nonzero(adata[:, secondary_TFs].X, axis=0).flatten()
                 secondary_TFs = [
                     tf for tf, nnz in zip(secondary_TFs, nnz_counts) if nnz >= int(0.5 * n_cells_threshold)
                 ]
@@ -6920,9 +6930,14 @@ class MuSIC_Interpreter(MuSIC):
 
                 regulator_features = all_TFs + secondary_TFs
                 # Prioritize those that are most coexpressed with at least one target:
-                regulator_expr = pd.DataFrame(
-                    adata[:, regulator_features].X.A, index=signal[subset_key].index, columns=regulator_features
-                )
+                if scipy.sparse.issparse(adata.X):
+                    regulator_expr = pd.DataFrame(
+                        adata[:, regulator_features].X.A, index=signal[subset_key].index, columns=regulator_features
+                    )
+                elif isinstance(adata.X, np.ndarray):  # adata.X might be np.ndarray
+                    regulator_expr = pd.DataFrame(
+                        adata[:, regulator_features].X, index=signal[subset_key].index, columns=regulator_features
+                    )
                 # Dataframe containing target expression:
                 ds_targets_df = signal[subset_key]
 
@@ -6963,7 +6978,10 @@ class MuSIC_Interpreter(MuSIC):
                 counts = adata[:, regulator_features].copy()
 
                 # Convert to dataframe:
-                counts_df = pd.DataFrame(counts.X.toarray(), index=counts.obs_names, columns=counts.var_names)
+                if scipy.sparse.issparse(adata.X):
+                    counts_df = pd.DataFrame(counts.X.toarray(), index=counts.obs_names, columns=counts.var_names)
+                elif isinstance(counts.X, np.ndarray):
+                    counts_df = pd.DataFrame(counts.X, index=counts.obs_names, columns=counts.var_names)
                 # combined_df = pd.concat([counts_df, signal[subset_key]], axis=1)
 
                 # Store the targets (ligands/receptors) to AnnData object, save to file path:
@@ -7129,6 +7147,7 @@ class MuSIC_Interpreter(MuSIC):
         kwargs["bw_fixed"] = True
         kwargs["total_counts_threshold"] = self.total_counts_threshold
         kwargs["total_counts_key"] = self.total_counts_key
+        kwargs["distr"] = self.distr
 
         # Use the same output directory as the main model, add folder demarcating results from downstream task:
         output_dir = os.path.dirname(self.output_path)
@@ -7613,6 +7632,7 @@ class MuSIC_Interpreter(MuSIC):
                         all_cells_affected = dm[dm[f"regulator_{interaction}"] > 0]
                     else:
                         all_cells_affected = dm[dm[interaction] > 0]
+
                     specificity = (all_coeffs_target.loc[all_cells_affected.index, interaction] != 0).mean()
                     all_plot_values.loc[interaction, target] = specificity
         all_plot_values.index = [replace_col_with_collagens(f) for f in all_plot_values.index]


### PR DESCRIPTION
Most of my changes are adding additional type checks for anndata object, since the obs_names could be numeric and adata.X could be a np.ndarray instead of a sparse array. 

There's also some changes for deprecated code, like it is not allowed to use set as a subscription on dataframes now.