### PR TITLE
Optimized SCC performance & fix some bugs

### DIFF
--- a/spateo/tools/CCI_effects_modeling/MuSIC_downstream.py
+++ b/spateo/tools/CCI_effects_modeling/MuSIC_downstream.py
@@ -539,7 +539,7 @@ class MuSIC_Interpreter(MuSIC):
                 data=df,
                 x="Gene",
                 y="Pearson coefficient",
-                palette=colors["Pearson coefficient"],
+                # palette=colors["Pearson coefficient"],
                 edgecolor="black",
                 dodge=True,
             )
@@ -567,7 +567,7 @@ class MuSIC_Interpreter(MuSIC):
                 data=df,
                 x="Gene",
                 y="Spearman coefficient",
-                palette=colors["Spearman coefficient"],
+                # palette=colors["Spearman coefficient"],
                 edgecolor="black",
                 dodge=True,
             )
@@ -593,7 +593,7 @@ class MuSIC_Interpreter(MuSIC):
                 data=df,
                 x="Gene",
                 y="Pearson coefficient (expressing cells)",
-                palette=colors["Pearson coefficient (expressing cells)"],
+                # palette=colors["Pearson coefficient (expressing cells)"],
                 edgecolor="black",
                 dodge=True,
             )
@@ -619,7 +619,7 @@ class MuSIC_Interpreter(MuSIC):
                 data=df,
                 x="Gene",
                 y="Spearman coefficient (expressing cells)",
-                palette=colors["Spearman coefficient (expressing cells)"],
+                # palette=colors["Spearman coefficient (expressing cells)"],
                 edgecolor="black",
                 dodge=True,
             )
@@ -4173,8 +4173,8 @@ class MuSIC_Interpreter(MuSIC):
             vmin = 0
             vmax = 1 if normalize else df.max().max()
 
-            fig, ax = plt.subplots(nrows=1, ncols=1, figsize=figsize)
-            divider = make_axes_locatable(ax)
+            fig, axes = plt.subplots(nrows=1, ncols=1, figsize=figsize)
+            divider = make_axes_locatable(axes)
             ax2 = divider.append_axes("right", size=ax2_size, pad=0)
 
             # Keep track of groups:
@@ -4212,7 +4212,7 @@ class MuSIC_Interpreter(MuSIC):
                 vmin=vmin,
                 vmax=vmax,
                 mask=mask,
-                ax=ax,
+                ax=axes,
             )
 
             # Outer frame:
@@ -4221,7 +4221,7 @@ class MuSIC_Interpreter(MuSIC):
                 spine.set_linewidth(thickness * 2.5)
 
             # Adjust colorbar settings:
-            divider = make_axes_locatable(ax)
+            divider = make_axes_locatable(axes)
             # Append axes to the top of the plot, where the colorbar will be placed
             if df.shape[0] > df.shape[1]:
                 cax = divider.append_axes("top", size="30%", pad=0)
@@ -4236,11 +4236,11 @@ class MuSIC_Interpreter(MuSIC):
             cbar.ax.tick_params(labelsize=fontsize * 1.5)
             cbar.ax.set_aspect(0.02)
 
-            ax.set_xlabel(x_label, fontsize=fontsize * 1.25)
-            ax.set_ylabel("Cell Type-Specific Target", fontsize=fontsize * 1.25)
-            ax.tick_params(axis="x", labelsize=fontsize, rotation=90)
-            ax.tick_params(axis="y", labelsize=fontsize)
-            ax.set_title(title, fontsize=fontsize * 1.5, pad=20)
+            axes.set_xlabel(x_label, fontsize=fontsize * 1.25)
+            axes.set_ylabel("Cell Type-Specific Target", fontsize=fontsize * 1.25)
+            axes.tick_params(axis="x", labelsize=fontsize, rotation=90)
+            axes.tick_params(axis="y", labelsize=fontsize)
+            axes.set_title(title, fontsize=fontsize * 1.5, pad=20)
 
             # Use the saved name for the AnnData object to define part of the name of the saved file:
             base_name = os.path.basename(self.adata_path)
@@ -6908,7 +6908,6 @@ class MuSIC_Interpreter(MuSIC):
                 if scipy.sparse.issparse(adata.X):
                     nnz_counts = np.array(adata[:, all_TFs].X.getnnz(axis=0)).flatten()
                 else:
-                    # nnz_counts = np.array(adata[:, all_TFs].X.getnnz(axis=0)).flatten()
                     nnz_counts = np.count_nonzero(
                         adata[:, all_TFs].X, axis=0
                     ).flatten()  # np.ndarray have no getnnz attributes
@@ -7637,7 +7636,6 @@ class MuSIC_Interpreter(MuSIC):
                         all_cells_affected = dm[dm[f"regulator_{interaction}"] > 0]
                     else:
                         all_cells_affected = dm[dm[interaction] > 0]
-
                     specificity = (all_coeffs_target.loc[all_cells_affected.index, interaction] != 0).mean()
                     all_plot_values.loc[interaction, target] = specificity
         all_plot_values.index = [replace_col_with_collagens(f) for f in all_plot_values.index]

--- a/spateo/tools/cluster/leiden.py
+++ b/spateo/tools/cluster/leiden.py
@@ -5,6 +5,7 @@ import igraph
 import leidenalg
 import numpy as np
 import scipy
+import scipy.sparse
 from sklearn.neighbors import kneighbors_graph
 
 from ...configuration import SKM
@@ -87,6 +88,8 @@ def calculate_leiden_partition(
     if adj is not None:
         if isinstance(adj, np.ndarray):
             G = adj_to_igraph(adj.tolist())
+        elif scipy.sparse.issparse(adj):
+            G = adj_to_igraph(adj.A.tolist())
         else:
             G = igraph.Graph(n=adj.shape[0])
             for i, j in zip(*adj.nonzero()):

--- a/spateo/tools/cluster/utils.py
+++ b/spateo/tools/cluster/utils.py
@@ -295,7 +295,8 @@ def spatial_adj(
     _, adata = neighbors(
         adata,
         n_neighbors=s_neigh,
-        basis=spatial_key,
+        basis="spatial",
+        spatial_key=spatial_key,
         n_pca_components=n_pca_components,
     )
 


### PR DESCRIPTION
Spatial constrained clustering code in Spateo is very slow now even for small sparse matrix input. The problem is because when use sparse matrix input, the transformation from matrix to igraph takes a lot of time iterating edges. Directly convert sparse matrix input to dense solved the problem.

I also fixed some bugs in plot functions of the CCI model.