### PR TITLE
Deprecate sparse matrix `.A` attributes

### DIFF
--- a/spateo/configuration.py
+++ b/spateo/configuration.py
@@ -140,7 +140,7 @@ class SpateoAdataKeyManager:
         else:
             res_data = adata.layers[layer]
         if make_dense and sparse.issparse(res_data):
-            return res_data.A
+            return res_data.toarray()
         if copy:
             return res_data.copy()
         return res_data

--- a/spateo/io/utils.py
+++ b/spateo/io/utils.py
@@ -234,7 +234,7 @@ def bin_matrix(X: Union[np.ndarray, spmatrix], binsize: int) -> Union[np.ndarray
     def _bin_sparse(X):
         nz = X.nonzero()
         x, y = nz
-        data = X[nz].toarray().flatten()
+        data = X[nz].A.flatten()
         x_bin = bin_indices(x, 0, binsize)
         y_bin = bin_indices(y, 0, binsize)
         return csr_matrix((data, (x_bin, y_bin)), shape=shape, dtype=X.dtype)

--- a/spateo/io/utils.py
+++ b/spateo/io/utils.py
@@ -234,7 +234,7 @@ def bin_matrix(X: Union[np.ndarray, spmatrix], binsize: int) -> Union[np.ndarray
     def _bin_sparse(X):
         nz = X.nonzero()
         x, y = nz
-        data = X[nz].A.flatten()
+        data = X[nz].toarray().flatten()
         x_bin = bin_indices(x, 0, binsize)
         y_bin = bin_indices(y, 0, binsize)
         return csr_matrix((data, (x_bin, y_bin)), shape=shape, dtype=X.dtype)

--- a/spateo/preprocessing/aggregate.py
+++ b/spateo/preprocessing/aggregate.py
@@ -33,7 +33,7 @@ def bin_adata(
     adata.obsm[coords_key] = (adata.obsm[coords_key] // bin_size).astype(np.int32)
 
     if scipy.issparse(adata.X):
-        df = pd.DataFrame(adata.X.A, columns=adata.var_names)
+        df = pd.DataFrame(adata.X.toarray(), columns=adata.var_names)
     else:
         df = pd.DataFrame(adata.X, columns=adata.var_names)
 

--- a/spateo/segmentation/density.py
+++ b/spateo/segmentation/density.py
@@ -121,7 +121,7 @@ def _segment_densities(
     # Make dense and normalize.
     if issparse(X):
         lm.main_debug("Converting to dense matrix.")
-        X = X.A
+        X = X.toarray()
     lm.main_debug("Normalizing matrix.")
     X = X / X.max()
 
@@ -199,7 +199,7 @@ def segment_densities(
         X = bin_matrix(X, binsize)
         if issparse(X):
             lm.main_debug("Converting to dense matrix.")
-            X = X.A
+            X = X.toarray()
     lm.main_info("Finding density bins.")
     bins = _segment_densities(X, k, dk, distance_threshold)
     if background is not False:

--- a/spateo/segmentation/icell.py
+++ b/spateo/segmentation/icell.py
@@ -264,7 +264,7 @@ def _score_pixels(
     # Convert X to dense array
     if issparse(X):
         lm.main_debug("Converting X to dense array.")
-        X = X.A
+        X = X.toarray()
 
     # All methods require some kind of 2D convolution to start off
     lm.main_debug(f"Computing 2D convolution with k={k}.")

--- a/spateo/svg/get_svg.py
+++ b/spateo/svg/get_svg.py
@@ -228,7 +228,7 @@ def cal_wass_dis_for_genes(
     ws = []
     pos_rs = []
     if issparse(adata.X):
-        df = pd.DataFrame(adata.X.A, columns=adata.var_names)
+        df = pd.DataFrame(adata.X.toarray(), columns=adata.var_names)
     else:
         df = pd.DataFrame(adata.X, columns=adata.var_names)
 
@@ -303,7 +303,7 @@ def cal_wass_dist_bs(
         b = target
     if isinstance(target, str):
         b = (
-            bin_scale_adata[:, target].X.A.flatten()
+            bin_scale_adata[:, target].X.toarray().flatten()
             if issparse(bin_scale_adata[:, target].X)
             else bin_scale_adata[:, target].X.flatten()
         )
@@ -411,7 +411,7 @@ def cal_wass_dis_nobs(
         b = target
     if isinstance(target, str):
         b = (
-            bin_scale_adata[:, target].X.A.flatten()
+            bin_scale_adata[:, target].X.toarray().flatten()
             if issparse(bin_scale_adata[:, target].X)
             else bin_scale_adata[:, target].X.flatten()
         )
@@ -527,7 +527,7 @@ def cal_wass_dis_target_on_genes(
         gene_set = bin_scale_adata.var_names
 
     if issparse(bin_scale_adata.X):
-        df = pd.DataFrame(bin_scale_adata.X.A, columns=bin_scale_adata.var_names)
+        df = pd.DataFrame(bin_scale_adata.X.toarray(), columns=bin_scale_adata.var_names)
     else:
         df = pd.DataFrame(bin_scale_adata.X, columns=bin_scale_adata.var_names)
 

--- a/spateo/svg/get_svg_between_slice.py
+++ b/spateo/svg/get_svg_between_slice.py
@@ -137,12 +137,12 @@ def cal_gw_dis_on_genes(inp1, inp2):
     pos_r1s = []
     pos_r2s = []
     if issparse(adata1.X):
-        df1 = pd.DataFrame(adata1.X.A, columns=adata1.var_names)
+        df1 = pd.DataFrame(adata1.X.toarray(), columns=adata1.var_names)
     else:
         df1 = pd.DataFrame(adata1.X, columns=adata1.var_names)
 
     if issparse(adata2.X):
-        df2 = pd.DataFrame(adata2.X.A, columns=adata2.var_names)
+        df2 = pd.DataFrame(adata2.X.toarray(), columns=adata2.var_names)
     else:
         df2 = pd.DataFrame(adata2.X, columns=adata2.var_names)
 

--- a/spateo/svg/utils.py
+++ b/spateo/svg/utils.py
@@ -34,7 +34,7 @@ def bin_adata(
     adata = adata.copy()
     adata.obsm[layer] = (adata.obsm[layer] // bin_size).astype(np.int32)
     df = (
-        pd.DataFrame(adata.X.A, columns=adata.var_names)
+        pd.DataFrame(adata.X.toarray(), columns=adata.var_names)
         if issparse(adata.X)
         else pd.DataFrame(adata.X, columns=adata.var_names)
     )
@@ -66,12 +66,12 @@ def shuffle_adata(
         return adata
     np.random.seed(seed)
     if issparse(adata.X):
-        tmp = adata.X.A
+        tmp = adata.X.toarray()
         if replace:
             tmp = tmp[np.random.randint(len(tmp), size=len(tmp))]
         else:
             np.random.shuffle(tmp)
-        adata.X.A = tmp
+        adata.X = csr_matrix(tmp)
     else:
         tmp = adata.X
         if replace:
@@ -115,7 +115,7 @@ def get_genes_by_pos_ratio(
         AnnData object.
     """
     adata = adata.copy()
-    adata.var["nCells"] = np.sum(adata.X.A > 0, axis=0) if issparse(adata.X) else np.sum(adata.X > 0, axis=0)
+    adata.var["nCells"] = np.sum(adata.X.toarray() > 0, axis=0) if issparse(adata.X) else np.sum(adata.X > 0, axis=0)
     adata.var["raw_pos_rate"] = adata.var["nCells"] / adata.n_obs
     return adata.var_names[adata.var["nCells"] / adata.n_obs > pos_ratio].to_list(), adata
 
@@ -134,12 +134,12 @@ def add_pos_ratio_to_adata(adata: AnnData, layer: str = None, var_name: str = "r
     """
     if layer:
         adata.var[var_name] = (
-            np.sum(adata.layers[layer].A > 0, axis=0)
+            np.sum(adata.layers[layer].toarray() > 0, axis=0)
             if issparse(adata.layers[layer])
             else np.sum(adata.layers[layer] > 0, axis=0)
         )
     else:
-        adata.var[var_name] = np.sum(adata.X.A > 0, axis=0) if issparse(adata.X) else np.sum(adata.X > 0, axis=0)
+        adata.var[var_name] = np.sum(adata.X.toarray() > 0, axis=0) if issparse(adata.X) else np.sum(adata.X > 0, axis=0)
     adata.var[var_name] = adata.var[var_name] / adata.n_obs
 
 
@@ -175,17 +175,17 @@ def cal_geodesic_distance(
     # remove islated one cell
     b = adata[
         np.min(
-            adata.obsp["spatial_distances"].A,
+            adata.obsp["spatial_distances"].toarray(),
             axis=1,
             initial=1e10,
-            where=np.array(adata.obsp["spatial_distances"].A > 0),
+            where=np.array(adata.obsp["spatial_distances"].toarray() > 0),
         )
         <= min_dis_cutoff
     ]
     lm.main_info(f"The cell/buckets number after filtering by min_dis_cutoff is {len(b)}")
 
     # remove sparse cells
-    b = b[np.max(b.obsp["spatial_distances"].A, axis=1) <= max_dis_cutoff]
+    b = b[np.max(b.obsp["spatial_distances"].toarray(), axis=1) <= max_dis_cutoff]
     lm.main_info(f"The cell/buckets number after filtering by max_dis_cutoff is {len(b)}")
 
     dyn.tl.neighbors(
@@ -220,16 +220,16 @@ def cal_euclidean_distance(
     # remove islated one cell
     b = adata[
         np.min(
-            adata.obsp["spatial_distances"].A,
+            adata.obsp["spatial_distances"].toarray(),
             axis=1,
             initial=1e10,
-            where=np.array(adata.obsp["spatial_distances"].A > 0),
+            where=np.array(adata.obsp["spatial_distances"].toarray() > 0),
         )
         <= min_dis_cutoff
     ]
 
     # remove sparse cells
-    b = b[np.max(b.obsp["spatial_distances"].A, axis=1) <= max_dis_cutoff]
+    b = b[np.max(b.obsp["spatial_distances"].toarray(), axis=1) <= max_dis_cutoff]
 
     # from scipy.sparse import csr_matrix
     # from scipy.sparse.csgraph import floyd_warshall
@@ -259,19 +259,16 @@ def scale_to(
 
     """
     adata = adata.copy()
-    if issparse(adata.X):
-        adata.X.A = adata.X.A.astype(np.float64)
-    else:
-        adata.X = adata.X.astype(np.float64)
+    adata.X = adata.X.astype(np.float64)
 
     if to_median:
         if issparse(adata.X):
-            N = np.median(np.sum(adata.X.A, axis=1))
+            N = np.median(np.sum(adata.X.toarray(), axis=1))
         else:
             N = np.median(np.sum(adata.X, axis=1))
 
     if issparse(adata.X):
-        adata.X.A = (adata.X.A.T / (np.sum(adata.X.A, axis=1) / N)).T
+        adata.X = csr_matrix((adata.X.toarray().T / (np.sum(adata.X.toarray(), axis=1) / N)).T)
     else:
         adata.X = (adata.X.T / (np.sum(adata.X, axis=1) / N)).T
     return adata
@@ -325,13 +322,10 @@ def loess_reg(
     layers: str = "X",
 ) -> AnnData:
     adata = adata.copy()
-    if issparse(adata.X):
-        adata.X.A = adata.X.A.astype(np.float64)
-    else:
-        adata.X = adata.X.astype(np.float64)
+    adata.X = adata.X.astype(np.float64)
 
     if issparse(adata.X):
-        adata.X.A = (adata.X.A.T / (np.sum(adata.X.A, axis=1) / N)).T
+        adata.X = csr_matrix((adata.X.toarray().T / (np.sum(adata.X.toarray(), axis=1) / N)).T)
     else:
         adata.X = (adata.X.T / (np.sum(adata.X, axis=1) / N)).T
     return adata

--- a/spateo/svg/utils.py
+++ b/spateo/svg/utils.py
@@ -139,7 +139,9 @@ def add_pos_ratio_to_adata(adata: AnnData, layer: str = None, var_name: str = "r
             else np.sum(adata.layers[layer] > 0, axis=0)
         )
     else:
-        adata.var[var_name] = np.sum(adata.X.toarray() > 0, axis=0) if issparse(adata.X) else np.sum(adata.X > 0, axis=0)
+        adata.var[var_name] = (
+            np.sum(adata.X.toarray() > 0, axis=0) if issparse(adata.X) else np.sum(adata.X > 0, axis=0)
+        )
     adata.var[var_name] = adata.var[var_name] / adata.n_obs
 
 

--- a/spateo/tdr/interpolations/interpolation_dl.py
+++ b/spateo/tdr/interpolations/interpolation_dl.py
@@ -60,7 +60,7 @@ def deep_intepretation(
     if len(var_keys) != 0:
         var_data = source_adata[:, var_keys].X
         if issparse(var_data):
-            var_data = var_data.A
+            var_data = var_data.toarray()
         info_data = np.c_[info_data, var_data]
     info_data = info_data[:, 1:]
 

--- a/spateo/tdr/interpolations/interpolation_gp.py
+++ b/spateo/tdr/interpolations/interpolation_gp.py
@@ -52,7 +52,7 @@ class Imputation_GPR:
         if len(var_keys) != 0:
             var_data = source_adata[:, var_keys].X
             if issparse(var_data):
-                var_data = var_data.A
+                var_data = var_data.toarray()
             info_data = np.c_[info_data, var_data]
         info_data = info_data[:, 1:]
 

--- a/spateo/tdr/interpolations/interpolation_sparseVFC.py
+++ b/spateo/tdr/interpolations/interpolation_sparseVFC.py
@@ -55,7 +55,7 @@ def kernel_interpolation(
     if len(var_keys) != 0:
         var_data = source_adata[:, var_keys].X
         if issparse(var_data):
-            var_data = var_data.A
+            var_data = var_data.toarray()
         info_data = np.c_[info_data, var_data]
     info_data = info_data[:, 1:]
 

--- a/spateo/tdr/models/models_backbone/backbone.py
+++ b/spateo/tdr/models/models_backbone/backbone.py
@@ -197,7 +197,7 @@ def backbone_scc(
     if "pp" not in adata.uns.keys():
         adata.uns["pp"] = {}
     genes, X_data = fetch_X_data(adata, genes, layer)
-    X_data = X_data.A if issparse(X_data) else X_data
+    X_data = X_data.toarray() if issparse(X_data) else X_data
     X_data = pd.DataFrame(X_data, columns=genes)
     X_data[adata_nodes_key] = adata.obs[adata_nodes_key].values
     X_data = pd.DataFrame(X_data.groupby(by=adata_nodes_key).mean())

--- a/spateo/tools/CCI_effects_modeling/MuSIC.py
+++ b/spateo/tools/CCI_effects_modeling/MuSIC.py
@@ -2,6 +2,7 @@
 Modeling cell-cell communication using a regression model that is considerate of the spatial heterogeneity of (and thus
 the context-dependency of the relationships of) the response variable.
 """
+
 import argparse
 import itertools
 import json
@@ -1699,13 +1700,11 @@ class MuSIC:
                     threshold = (
                         0.67
                         if len(receptor_cols) == 2
-                        else 0.5
-                        if len(receptor_cols) == 3
-                        else 0.4
-                        if len(receptor_cols) == 4
-                        else 0.33
-                        if len(receptor_cols) >= 5
-                        else 1
+                        else (
+                            0.5
+                            if len(receptor_cols) == 3
+                            else 0.4 if len(receptor_cols) == 4 else 0.33 if len(receptor_cols) >= 5 else 1
+                        )
                     )
                     # If overlap is greater than threshold, combine columns
                     if len(receptor_cols) > 1 and overlap > threshold:
@@ -1746,13 +1745,11 @@ class MuSIC:
                                 threshold = (
                                     0.67
                                     if len(combined_cols) == 2
-                                    else 0.5
-                                    if len(combined_cols) == 3
-                                    else 0.4
-                                    if len(combined_cols) == 4
-                                    else 0.33
-                                    if len(combined_cols) >= 5
-                                    else 1
+                                    else (
+                                        0.5
+                                        if len(combined_cols) == 3
+                                        else 0.4 if len(combined_cols) == 4 else 0.33 if len(combined_cols) >= 5 else 1
+                                    )
                                 )
                                 combined_receptor_df = receptor_df[(receptor_df[combined_cols] != 0).any(axis=1)]
                                 # Calculate overlap for combined ligands
@@ -2473,7 +2470,11 @@ class MuSIC:
             if hasattr(self, "targets_expr"):
                 targets = self.targets_expr.columns
                 y_arr = pd.DataFrame(
-                    self.adata[:, targets].X.toarray() if scipy.sparse.issparse(self.adata.X) else self.adata[:, targets].X,
+                    (
+                        self.adata[:, targets].X.toarray()
+                        if scipy.sparse.issparse(self.adata.X)
+                        else self.adata[:, targets].X
+                    ),
                     index=self.sample_names,
                     columns=targets,
                 )

--- a/spateo/tools/CCI_effects_modeling/MuSIC.py
+++ b/spateo/tools/CCI_effects_modeling/MuSIC.py
@@ -1703,7 +1703,11 @@ class MuSIC:
                         else (
                             0.5
                             if len(receptor_cols) == 3
-                            else 0.4 if len(receptor_cols) == 4 else 0.33 if len(receptor_cols) >= 5 else 1
+                            else 0.4
+                            if len(receptor_cols) == 4
+                            else 0.33
+                            if len(receptor_cols) >= 5
+                            else 1
                         )
                     )
                     # If overlap is greater than threshold, combine columns
@@ -1748,7 +1752,11 @@ class MuSIC:
                                     else (
                                         0.5
                                         if len(combined_cols) == 3
-                                        else 0.4 if len(combined_cols) == 4 else 0.33 if len(combined_cols) >= 5 else 1
+                                        else 0.4
+                                        if len(combined_cols) == 4
+                                        else 0.33
+                                        if len(combined_cols) >= 5
+                                        else 1
                                     )
                                 )
                                 combined_receptor_df = receptor_df[(receptor_df[combined_cols] != 0).any(axis=1)]

--- a/spateo/tools/CCI_effects_modeling/MuSIC.py
+++ b/spateo/tools/CCI_effects_modeling/MuSIC.py
@@ -759,7 +759,7 @@ class MuSIC:
 
             # Define ligand/receptor/pathway expression array:
             self.targets_expr = pd.DataFrame(
-                adata[:, targets].X.A if scipy.sparse.issparse(adata.X) else adata[:, targets].X,
+                adata[:, targets].X.toarray() if scipy.sparse.issparse(adata.X) else adata[:, targets].X,
                 index=adata.obs_names,
                 columns=targets,
             )
@@ -767,7 +767,7 @@ class MuSIC:
             adata_orig = adata.copy()
             adata_orig.X = adata.layers["original_counts"]
             targets_expr_raw = pd.DataFrame(
-                adata_orig[:, targets].X.A if scipy.sparse.issparse(adata.X) else adata_orig[:, targets].X,
+                adata_orig[:, targets].X.toarray() if scipy.sparse.issparse(adata.X) else adata_orig[:, targets].X,
                 index=adata.obs_names,
                 columns=targets,
             )
@@ -836,7 +836,7 @@ class MuSIC:
                         f"covariate to the X matrix."
                     )
             matched_obs_matrix = self.adata.obs[matched_obs].to_numpy()
-            matched_var_matrix = self.adata[:, matched_var_names].X.A
+            matched_var_matrix = self.adata[:, matched_var_names].X.toarray()
             cov_names = matched_obs + matched_var_names
             concatenated_matrix = np.concatenate((matched_obs_matrix, matched_var_matrix), axis=1)
             self.X = np.concatenate((self.X, concatenated_matrix), axis=1)
@@ -942,7 +942,7 @@ class MuSIC:
                 all_targets = [t for t in all_targets if t in self.grn.index]
 
                 self.targets_expr = pd.DataFrame(
-                    adata[:, all_targets].X.A if scipy.sparse.issparse(adata.X) else adata[:, all_targets].X,
+                    adata[:, all_targets].X.toarray() if scipy.sparse.issparse(adata.X) else adata[:, all_targets].X,
                     index=adata.obs_names,
                     columns=all_targets,
                 )
@@ -1157,7 +1157,7 @@ class MuSIC:
                 ligands = [l for l in ligands if l in adata.var_names]
 
                 self.ligands_expr = pd.DataFrame(
-                    adata[:, ligands].X.A if scipy.sparse.issparse(adata.X) else adata[:, ligands].X,
+                    adata[:, ligands].X.toarray() if scipy.sparse.issparse(adata.X) else adata[:, ligands].X,
                     index=adata.obs_names,
                     columns=ligands,
                 )
@@ -1294,7 +1294,7 @@ class MuSIC:
                 receptors = [r for r in receptors if r in adata.var_names]
 
                 self.receptors_expr = pd.DataFrame(
-                    adata[:, receptors].X.A if scipy.sparse.issparse(adata.X) else adata[:, receptors].X,
+                    adata[:, receptors].X.toarray() if scipy.sparse.issparse(adata.X) else adata[:, receptors].X,
                     index=adata.obs_names,
                     columns=receptors,
                 )
@@ -1451,7 +1451,7 @@ class MuSIC:
             targets = [t for t in targets if t in self.grn.index]
 
             self.targets_expr = pd.DataFrame(
-                adata[:, targets].X.A if scipy.sparse.issparse(adata.X) else adata[:, targets].X,
+                adata[:, targets].X.toarray() if scipy.sparse.issparse(adata.X) else adata[:, targets].X,
                 index=adata.obs_names,
                 columns=targets,
             )
@@ -1540,9 +1540,9 @@ class MuSIC:
                         matching_rows["type"].str.contains("Secreted Signaling").any()
                         or matching_rows["type"].str.contains("ECM-Receptor").any()
                     ):
-                        lagged_expr = spatial_weights_secreted.dot(expr_sparse).A.flatten()
+                        lagged_expr = spatial_weights_secreted.dot(expr_sparse).toarray().flatten()
                     else:
-                        lagged_expr = spatial_weights_membrane_bound.dot(expr_sparse).A.flatten()
+                        lagged_expr = spatial_weights_membrane_bound.dot(expr_sparse).toarray().flatten()
                     lagged_expr_mat[:, i] = lagged_expr
                 self.ligands_expr = pd.DataFrame(
                     lagged_expr_mat, index=adata.obs_names, columns=self.ligands_expr.columns
@@ -2029,7 +2029,7 @@ class MuSIC:
                         f"covariate to the X matrix."
                     )
             matched_obs_matrix = self.adata.obs[matched_obs].to_numpy()
-            matched_var_matrix = self.adata[:, matched_var_names].X.A
+            matched_var_matrix = self.adata[:, matched_var_names].X.toarray()
             cov_names = matched_obs + matched_var_names
             concatenated_matrix = np.concatenate((matched_obs_matrix, matched_var_matrix), axis=1)
             self.X = np.concatenate((self.X, concatenated_matrix), axis=1)
@@ -2453,7 +2453,7 @@ class MuSIC:
             if hasattr(self, "targets_expr"):
                 targets = self.targets_expr.columns
                 y_arr = pd.DataFrame(
-                    self.adata[:, targets].X.A if scipy.sparse.issparse(self.adata.X) else self.adata[:, targets].X,
+                    self.adata[:, targets].X.toarray() if scipy.sparse.issparse(self.adata.X) else self.adata[:, targets].X,
                     index=self.sample_names,
                     columns=targets,
                 )

--- a/spateo/tools/CCI_effects_modeling/MuSIC_downstream.py
+++ b/spateo/tools/CCI_effects_modeling/MuSIC_downstream.py
@@ -6737,7 +6737,7 @@ class MuSIC_Interpreter(MuSIC):
                         sig_df = sig_df.drop(col, axis=1)
                         for l in col.split("_"):
                             if scipy.sparse.issparse(self.adata.X):
-                                gene_expr = self.adata[:, l].X.A
+                                gene_expr = self.adata[:, l].X.toarray()
                             else:
                                 gene_expr = self.adata[:, l].X
                             sig_df[l] = gene_expr
@@ -6794,7 +6794,7 @@ class MuSIC_Interpreter(MuSIC):
                         sig_df = sig_df.drop(col, axis=1)
                         for r in col.split("_"):
                             if scipy.sparse.issparse(self.adata.X):
-                                gene_expr = self.adata[:, r].X.A
+                                gene_expr = self.adata[:, r].X.toarray()
                             else:
                                 gene_expr = self.adata[:, r].X
                             sig_df[r] = gene_expr
@@ -6839,7 +6839,7 @@ class MuSIC_Interpreter(MuSIC):
                 targets = [t for t in targets if t in self.adata.var_names]
                 targets = list(set(targets))
                 targets_expr = pd.DataFrame(
-                    self.adata[:, targets].X.A if scipy.sparse.issparse(self.adata.X) else self.adata[:, targets].X,
+                    self.adata[:, targets].X.toarray() if scipy.sparse.issparse(self.adata.X) else self.adata[:, targets].X,
                     index=self.adata.obs_names,
                     columns=targets,
                 )
@@ -6872,7 +6872,7 @@ class MuSIC_Interpreter(MuSIC):
                     ct_signaling = ct_signaling.var.index[sig_expr_percentage > self.target_expr_threshold]
 
                     sig_expr = pd.DataFrame(
-                        self.adata[:, ct_signaling].X.A
+                        self.adata[:, ct_signaling].X.toarray()
                         if scipy.sparse.issparse(self.adata.X)
                         else self.adata[:, ct_signaling].X,
                         index=self.sample_names,
@@ -6921,7 +6921,7 @@ class MuSIC_Interpreter(MuSIC):
                 regulator_features = all_TFs + secondary_TFs
                 # Prioritize those that are most coexpressed with at least one target:
                 regulator_expr = pd.DataFrame(
-                    adata[:, regulator_features].X.A, index=signal[subset_key].index, columns=regulator_features
+                    adata[:, regulator_features].X.toarray(), index=signal[subset_key].index, columns=regulator_features
                 )
                 # Dataframe containing target expression:
                 ds_targets_df = signal[subset_key]

--- a/spateo/tools/CCI_effects_modeling/MuSIC_downstream.py
+++ b/spateo/tools/CCI_effects_modeling/MuSIC_downstream.py
@@ -982,9 +982,9 @@ class MuSIC_Interpreter(MuSIC):
                 if len(strong_active_effects) >= 3:
                     adata.obs.loc[idx, "interaction_categories"] = "Multiple interactions"
                 elif len(strong_active_effects) == 2:
-                    adata.obs.loc[idx, "interaction_categories"] = (
-                        f"{strong_active_effects[0]} and {strong_active_effects[1]}"
-                    )
+                    adata.obs.loc[
+                        idx, "interaction_categories"
+                    ] = f"{strong_active_effects[0]} and {strong_active_effects[1]}"
                 elif len(active_effects) == 1:
                     adata.obs.loc[idx, "interaction_categories"] = active_effects[0]
             else:
@@ -1325,24 +1325,24 @@ class MuSIC_Interpreter(MuSIC):
         overlap = target_expressing.intersection(interaction_expressing)
 
         adata.obs[f"{interaction}_{target}"] = "Other"
-        adata.obs.loc[target_expressing, f"{interaction}_{target}"] = (
-            f"{target} only (no {interaction} in neighborhood and/or receptor)"
-        )
+        adata.obs.loc[
+            target_expressing, f"{interaction}_{target}"
+        ] = f"{target} only (no {interaction} in neighborhood and/or receptor)"
         if self.mod_type == "lr":
             ligand, receptor = interaction.split(":")
-            adata.obs.loc[interaction_expressing, f"{interaction}_{target}"] = (
-                f"{ligand.title()} in Neighborhood and {receptor}, no {target}"
-            )
-            adata.obs.loc[overlap, f"{interaction}_{target}"] = (
-                f"{ligand.title()} in Neighborhood, {receptor} and {target}"
-            )
+            adata.obs.loc[
+                interaction_expressing, f"{interaction}_{target}"
+            ] = f"{ligand.title()} in Neighborhood and {receptor}, no {target}"
+            adata.obs.loc[
+                overlap, f"{interaction}_{target}"
+            ] = f"{ligand.title()} in Neighborhood, {receptor} and {target}"
         elif self.mod_type == "ligand":
-            adata.obs.loc[interaction_expressing, f"{interaction}_{target}"] = (
-                f"{interaction.title()} in Neighborhood and Receptor, no {target}"
-            )
-            adata.obs.loc[overlap, f"{interaction}_{target}"] = (
-                f"{interaction.title()} in Neighborhood, Receptor and {target}"
-            )
+            adata.obs.loc[
+                interaction_expressing, f"{interaction}_{target}"
+            ] = f"{interaction.title()} in Neighborhood and Receptor, no {target}"
+            adata.obs.loc[
+                overlap, f"{interaction}_{target}"
+            ] = f"{interaction.title()} in Neighborhood, Receptor and {target}"
 
         color_mapping = dict(zip(adata.obs[f"{interaction}_{target}"].value_counts().index, godsnot_102))
         color_mapping["Other"] = "#D3D3D3"
@@ -3537,9 +3537,9 @@ class MuSIC_Interpreter(MuSIC):
         adata.obs.loc[
             target_expressing_selected, f"{interaction}_{target}_{select_examples_criterion}_example_points"
         ] = target_expression
-        adata.obs.loc[neighbors_selected, f"{interaction}_{target}_{select_examples_criterion}_example_points"] = (
-            ligand_expression
-        )
+        adata.obs.loc[
+            neighbors_selected, f"{interaction}_{target}_{select_examples_criterion}_example_points"
+        ] = ligand_expression
 
         if display_plot:
             # plotly to create 3D scatter plot:
@@ -5569,13 +5569,13 @@ class MuSIC_Interpreter(MuSIC):
         if store_summed_potential:
             if self.mod_type == "niche":
                 if receiver_cell_type is None:
-                    self.adata.obs[f"norm_sum_sent_effect_potential_{sender_cell_type}_for_{target}"] = (
-                        normalized_effect_potential_sum_sender
-                    )
+                    self.adata.obs[
+                        f"norm_sum_sent_effect_potential_{sender_cell_type}_for_{target}"
+                    ] = normalized_effect_potential_sum_sender
 
-                    self.adata.obs[f"norm_sum_received_effect_potential_from_{sender_cell_type}_for_{target}"] = (
-                        normalized_effect_potential_sum_receiver
-                    )
+                    self.adata.obs[
+                        f"norm_sum_received_effect_potential_from_{sender_cell_type}_for_{target}"
+                    ] = normalized_effect_potential_sum_receiver
                 else:
                     self.adata.obs[
                         f"norm_sum_sent_{sender_cell_type}_effect_potential_to_{receiver_cell_type}_for_{target}"
@@ -5590,26 +5590,26 @@ class MuSIC_Interpreter(MuSIC):
                     ligand = replace_col_with_collagens(ligand)
                     ligand = replace_hla_with_hlas(ligand)
 
-                self.adata.obs[f"norm_sum_sent_effect_potential_{ligand}_for_{target}"] = (
-                    normalized_effect_potential_sum_sender
-                )
+                self.adata.obs[
+                    f"norm_sum_sent_effect_potential_{ligand}_for_{target}"
+                ] = normalized_effect_potential_sum_sender
 
-                self.adata.obs[f"norm_sum_received_effect_potential_from_{ligand}_for_{target}"] = (
-                    normalized_effect_potential_sum_receiver
-                )
+                self.adata.obs[
+                    f"norm_sum_received_effect_potential_from_{ligand}_for_{target}"
+                ] = normalized_effect_potential_sum_receiver
 
             elif self.mod_type == "lr":
                 if "/" in ligand:
                     ligand = replace_col_with_collagens(ligand)
                     ligand = replace_hla_with_hlas(ligand)
 
-                self.adata.obs[f"norm_sum_sent_effect_potential_{ligand}_for_{target}_via_{receptor}"] = (
-                    normalized_effect_potential_sum_sender
-                )
+                self.adata.obs[
+                    f"norm_sum_sent_effect_potential_{ligand}_for_{target}_via_{receptor}"
+                ] = normalized_effect_potential_sum_sender
 
-                self.adata.obs[f"norm_sum_received_effect_potential_from_{ligand}_for_{target}_via_{receptor}"] = (
-                    normalized_effect_potential_sum_receiver
-                )
+                self.adata.obs[
+                    f"norm_sum_received_effect_potential_from_{ligand}_for_{target}_via_{receptor}"
+                ] = normalized_effect_potential_sum_receiver
 
             self.adata.obs["effect_sign"] = effect_sign.reshape(-1, 1)
 
@@ -6940,7 +6940,9 @@ class MuSIC_Interpreter(MuSIC):
                 # Prioritize those that are most coexpressed with at least one target:
                 if scipy.sparse.issparse(adata.X):
                     regulator_expr = pd.DataFrame(
-                        adata[:, regulator_features].X.toarray(), index=signal[subset_key].index, columns=regulator_features
+                        adata[:, regulator_features].X.toarray(),
+                        index=signal[subset_key].index,
+                        columns=regulator_features,
                     )
                 elif isinstance(adata.X, np.ndarray):  # adata.X might be np.ndarray
                     regulator_expr = pd.DataFrame(

--- a/spateo/tools/CCI_effects_modeling/MuSIC_downstream.py
+++ b/spateo/tools/CCI_effects_modeling/MuSIC_downstream.py
@@ -9,6 +9,7 @@ These include:
     - following spatially-aware regression (or a sequence of spatially-aware regressions), overlay the directionality
     of the predicted influence of the ligand on downstream expression.
 """
+
 import argparse
 import collections
 import gc
@@ -981,9 +982,9 @@ class MuSIC_Interpreter(MuSIC):
                 if len(strong_active_effects) >= 3:
                     adata.obs.loc[idx, "interaction_categories"] = "Multiple interactions"
                 elif len(strong_active_effects) == 2:
-                    adata.obs.loc[
-                        idx, "interaction_categories"
-                    ] = f"{strong_active_effects[0]} and {strong_active_effects[1]}"
+                    adata.obs.loc[idx, "interaction_categories"] = (
+                        f"{strong_active_effects[0]} and {strong_active_effects[1]}"
+                    )
                 elif len(active_effects) == 1:
                     adata.obs.loc[idx, "interaction_categories"] = active_effects[0]
             else:
@@ -1324,24 +1325,24 @@ class MuSIC_Interpreter(MuSIC):
         overlap = target_expressing.intersection(interaction_expressing)
 
         adata.obs[f"{interaction}_{target}"] = "Other"
-        adata.obs.loc[
-            target_expressing, f"{interaction}_{target}"
-        ] = f"{target} only (no {interaction} in neighborhood and/or receptor)"
+        adata.obs.loc[target_expressing, f"{interaction}_{target}"] = (
+            f"{target} only (no {interaction} in neighborhood and/or receptor)"
+        )
         if self.mod_type == "lr":
             ligand, receptor = interaction.split(":")
-            adata.obs.loc[
-                interaction_expressing, f"{interaction}_{target}"
-            ] = f"{ligand.title()} in Neighborhood and {receptor}, no {target}"
-            adata.obs.loc[
-                overlap, f"{interaction}_{target}"
-            ] = f"{ligand.title()} in Neighborhood, {receptor} and {target}"
+            adata.obs.loc[interaction_expressing, f"{interaction}_{target}"] = (
+                f"{ligand.title()} in Neighborhood and {receptor}, no {target}"
+            )
+            adata.obs.loc[overlap, f"{interaction}_{target}"] = (
+                f"{ligand.title()} in Neighborhood, {receptor} and {target}"
+            )
         elif self.mod_type == "ligand":
-            adata.obs.loc[
-                interaction_expressing, f"{interaction}_{target}"
-            ] = f"{interaction.title()} in Neighborhood and Receptor, no {target}"
-            adata.obs.loc[
-                overlap, f"{interaction}_{target}"
-            ] = f"{interaction.title()} in Neighborhood, Receptor and {target}"
+            adata.obs.loc[interaction_expressing, f"{interaction}_{target}"] = (
+                f"{interaction.title()} in Neighborhood and Receptor, no {target}"
+            )
+            adata.obs.loc[overlap, f"{interaction}_{target}"] = (
+                f"{interaction.title()} in Neighborhood, Receptor and {target}"
+            )
 
         color_mapping = dict(zip(adata.obs[f"{interaction}_{target}"].value_counts().index, godsnot_102))
         color_mapping["Other"] = "#D3D3D3"
@@ -3536,9 +3537,9 @@ class MuSIC_Interpreter(MuSIC):
         adata.obs.loc[
             target_expressing_selected, f"{interaction}_{target}_{select_examples_criterion}_example_points"
         ] = target_expression
-        adata.obs.loc[
-            neighbors_selected, f"{interaction}_{target}_{select_examples_criterion}_example_points"
-        ] = ligand_expression
+        adata.obs.loc[neighbors_selected, f"{interaction}_{target}_{select_examples_criterion}_example_points"] = (
+            ligand_expression
+        )
 
         if display_plot:
             # plotly to create 3D scatter plot:
@@ -5568,13 +5569,13 @@ class MuSIC_Interpreter(MuSIC):
         if store_summed_potential:
             if self.mod_type == "niche":
                 if receiver_cell_type is None:
-                    self.adata.obs[
-                        f"norm_sum_sent_effect_potential_{sender_cell_type}_for_{target}"
-                    ] = normalized_effect_potential_sum_sender
+                    self.adata.obs[f"norm_sum_sent_effect_potential_{sender_cell_type}_for_{target}"] = (
+                        normalized_effect_potential_sum_sender
+                    )
 
-                    self.adata.obs[
-                        f"norm_sum_received_effect_potential_from_{sender_cell_type}_for_{target}"
-                    ] = normalized_effect_potential_sum_receiver
+                    self.adata.obs[f"norm_sum_received_effect_potential_from_{sender_cell_type}_for_{target}"] = (
+                        normalized_effect_potential_sum_receiver
+                    )
                 else:
                     self.adata.obs[
                         f"norm_sum_sent_{sender_cell_type}_effect_potential_to_{receiver_cell_type}_for_{target}"
@@ -5589,26 +5590,26 @@ class MuSIC_Interpreter(MuSIC):
                     ligand = replace_col_with_collagens(ligand)
                     ligand = replace_hla_with_hlas(ligand)
 
-                self.adata.obs[
-                    f"norm_sum_sent_effect_potential_{ligand}_for_{target}"
-                ] = normalized_effect_potential_sum_sender
+                self.adata.obs[f"norm_sum_sent_effect_potential_{ligand}_for_{target}"] = (
+                    normalized_effect_potential_sum_sender
+                )
 
-                self.adata.obs[
-                    f"norm_sum_received_effect_potential_from_{ligand}_for_{target}"
-                ] = normalized_effect_potential_sum_receiver
+                self.adata.obs[f"norm_sum_received_effect_potential_from_{ligand}_for_{target}"] = (
+                    normalized_effect_potential_sum_receiver
+                )
 
             elif self.mod_type == "lr":
                 if "/" in ligand:
                     ligand = replace_col_with_collagens(ligand)
                     ligand = replace_hla_with_hlas(ligand)
 
-                self.adata.obs[
-                    f"norm_sum_sent_effect_potential_{ligand}_for_{target}_via_{receptor}"
-                ] = normalized_effect_potential_sum_sender
+                self.adata.obs[f"norm_sum_sent_effect_potential_{ligand}_for_{target}_via_{receptor}"] = (
+                    normalized_effect_potential_sum_sender
+                )
 
-                self.adata.obs[
-                    f"norm_sum_received_effect_potential_from_{ligand}_for_{target}_via_{receptor}"
-                ] = normalized_effect_potential_sum_receiver
+                self.adata.obs[f"norm_sum_received_effect_potential_from_{ligand}_for_{target}_via_{receptor}"] = (
+                    normalized_effect_potential_sum_receiver
+                )
 
             self.adata.obs["effect_sign"] = effect_sign.reshape(-1, 1)
 
@@ -6846,7 +6847,11 @@ class MuSIC_Interpreter(MuSIC):
                 targets = [t for t in targets if t in self.adata.var_names]
                 targets = list(set(targets))
                 targets_expr = pd.DataFrame(
-                    self.adata[:, targets].X.toarray() if scipy.sparse.issparse(self.adata.X) else self.adata[:, targets].X,
+                    (
+                        self.adata[:, targets].X.toarray()
+                        if scipy.sparse.issparse(self.adata.X)
+                        else self.adata[:, targets].X
+                    ),
                     index=self.adata.obs_names,
                     columns=targets,
                 )
@@ -6879,9 +6884,11 @@ class MuSIC_Interpreter(MuSIC):
                     ct_signaling = ct_signaling.var.index[sig_expr_percentage > self.target_expr_threshold]
 
                     sig_expr = pd.DataFrame(
-                        self.adata[:, ct_signaling].X.toarray()
-                        if scipy.sparse.issparse(self.adata.X)
-                        else self.adata[:, ct_signaling].X,
+                        (
+                            self.adata[:, ct_signaling].X.toarray()
+                            if scipy.sparse.issparse(self.adata.X)
+                            else self.adata[:, ct_signaling].X
+                        ),
                         index=self.sample_names,
                         columns=ct_signaling,
                     )

--- a/spateo/tools/CCI_effects_modeling/regression_utils.py
+++ b/spateo/tools/CCI_effects_modeling/regression_utils.py
@@ -824,7 +824,7 @@ def permutation_testing(
         pval: The calculated p-value.
     """
     if scipy.sparse.isspmatrix_csr(data):
-        data = data.A
+        data = data.toarray()
 
     if subset_rows is not None:
         if subset_cols is not None:

--- a/spateo/tools/architype.py
+++ b/spateo/tools/architype.py
@@ -146,9 +146,9 @@ def archetypes(
     """
 
     if layer is None:
-        exp = adata[:, moran_i_genes].X.A
+        exp = adata[:, moran_i_genes].X.toarray()
     else:
-        exp = adata[:, moran_i_genes].layers[layer].A
+        exp = adata[:, moran_i_genes].layers[layer].toarray()
 
     archetypes, clusters, gene_corrs = find_spatial_archetypes(num_clusters, exp.T)
     arch_cols = ["archetype %d" % i for i in np.arange(num_clusters)]
@@ -195,9 +195,9 @@ def archetypes_genes(
     """
 
     if layer is None:
-        exp = adata[:, moran_i_genes].X.A
+        exp = adata[:, moran_i_genes].X.toarray()
     else:
-        exp = adata[:, moran_i_genes].layers[layer].A
+        exp = adata[:, moran_i_genes].layers[layer].toarray()
 
     archetypes_dict = {}
 

--- a/spateo/tools/cci_two_cluster.py
+++ b/spateo/tools/cci_two_cluster.py
@@ -280,7 +280,7 @@ def find_cci_two_group(
         # real lr_cp_exp_score
         ligand_data = adata[cell_pair["cell_sender"], lr_network["from"]]
         receptor_data = adata[cell_pair["cell_receiver"], lr_network["to"]]
-        lr_data = ligand_data.X.A * receptor_data.X.A if x_sparse else ligand_data.X * receptor_data.X
+        lr_data = ligand_data.X.toarray() * receptor_data.X.toarray() if x_sparse else ligand_data.X * receptor_data.X
         lr_data = np.array(lr_data)
         if cell_pair.shape[0] == 0:
             lr_prod = np.zeros(lr_network.shape[0])
@@ -312,7 +312,7 @@ def find_cci_two_group(
             per_ligand_data = adata[per_sender_id, lr_network["from"]]
             per_receptor_data = adata[per_receiver_id, lr_network["to"]]
             per_lr_data = (
-                per_ligand_data.X.A * per_receptor_data.X.A if x_sparse else per_ligand_data.X * per_receptor_data.X
+                per_ligand_data.X.toarray() * per_receptor_data.X.toarray() if x_sparse else per_ligand_data.X * per_receptor_data.X
             )
             per_lr_co_exp_ratio = np.apply_along_axis(lambda x: np.sum(x > 0) / x.size, 0, per_lr_data)
             if np.isnan(per_lr_co_exp_ratio).all():
@@ -359,9 +359,9 @@ def calculate_group_pair_lr_pair(
 
     ## ligand-20 groups; receptor-20 groups
     for g in cols:
-        meanl = np.mean(adata_l[adata_l.obs[group] == g].X.A, axis=0)
+        meanl = np.mean(adata_l[adata_l.obs[group] == g].X.toarray(), axis=0)
         dfl[g] = meanl
-        meanr = np.mean(adata_r[adata_r.obs[group] == g].X.A, axis=0)
+        meanr = np.mean(adata_r[adata_r.obs[group] == g].X.toarray(), axis=0)
         dfr[g] = meanr
 
     ## group_pairs

--- a/spateo/tools/cci_two_cluster.py
+++ b/spateo/tools/cci_two_cluster.py
@@ -374,7 +374,9 @@ def find_cci_two_group(
             per_ligand_data = adata[per_sender_id, lr_network["from"]]
             per_receptor_data = adata[per_receiver_id, lr_network["to"]]
             per_lr_data = (
-                per_ligand_data.X.toarray() * per_receptor_data.X.toarray() if x_sparse else per_ligand_data.X * per_receptor_data.X
+                per_ligand_data.X.toarray() * per_receptor_data.X.toarray()
+                if x_sparse
+                else per_ligand_data.X * per_receptor_data.X
             )
             per_lr_co_exp_ratio = np.apply_along_axis(lambda x: np.sum(x > 0) / x.size, 0, per_lr_data)
             if np.isnan(per_lr_co_exp_ratio).all():

--- a/spateo/tools/cell_communication.py
+++ b/spateo/tools/cell_communication.py
@@ -380,7 +380,9 @@ def predict_ligand_activities(
         response_expressed_genes = list(set(expressed_genes_receiver) & set(ligand_target_matrix.index))
         response_expressed_genes_df = pd.DataFrame(response_expressed_genes)
         response_expressed_genes_df = response_expressed_genes_df.rename(columns={0: "gene"})
-        response_expressed_genes_df["avg_expr"] = np.mean(adata[receiver_cells, response_expressed_genes].X.toarray(), axis=0)
+        response_expressed_genes_df["avg_expr"] = np.mean(
+            adata[receiver_cells, response_expressed_genes].X.toarray(), axis=0
+        )
         lt_matrix = ligand_target_matrix[potential_ligands.tolist()].loc[response_expressed_genes_df["gene"].tolist()]
         de = []
         for ligand in lt_matrix:

--- a/spateo/tools/cell_communication.py
+++ b/spateo/tools/cell_communication.py
@@ -108,7 +108,7 @@ def niches(
     if len(expressed_receptor) == 0:
         raise ValueError(f"No intersected receptor between your adata object" f" and lr_network dataset.")
     lr_network = lr_network[lr_network["to"].isin(expressed_receptor)]
-    ligand_matrix = adata[:, lr_network["from"]].X.A.T if x_sparse else adata[:, lr_network["from"]].X.T
+    ligand_matrix = adata[:, lr_network["from"]].X.toarray().T if x_sparse else adata[:, lr_network["from"]].X.T
 
     # spatial neighbors
     if spatial_neighbors not in adata.uns.keys():
@@ -133,14 +133,14 @@ def niches(
             row, col = np.diag_indices_from(nw["weights"])
             nw["weights"][row, col] = 1
             weight = np.zeros(shape=(adata.n_obs, k))
-            for i, row in enumerate(nw["weights"].A):
+            for i, row in enumerate(nw["weights"].toarray()):
                 weight[i, :] = 1 / row[nw["neighbors"][i]]
             for i in range(ligand_matrix.shape[1]):
-                receptor_matrix = adata[nw["neighbors"][i], lr_network["to"]].X.A.T * weight[i, :]
+                receptor_matrix = adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T * weight[i, :]
                 X[:, i * k : (i + 1) * k] = receptor_matrix * ligand_matrix[:, i].reshape(-1, 1)
         else:
             for i in range(ligand_matrix.shape[1]):
-                receptor_matrix = adata[nw["neighbors"][i], lr_network["to"]].X.A.T
+                receptor_matrix = adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T
                 X[:, i * k : (i + 1) * k] = receptor_matrix * ligand_matrix[:, i].reshape(-1, 1)
         # bucket-bucket pair
         cell_pair = []
@@ -158,24 +158,24 @@ def niches(
             row, col = np.diag_indices_from(nw["weights"])
             nw["weights"][row, col] = 1
             weight = np.zeros(shape=(adata.n_obs, k))
-            for i, row in enumerate(nw["weights"].A):
+            for i, row in enumerate(nw["weights"].toarray()):
                 weight[i, :] = 1 / row[nw["neighbors"][i]]
             for i in range(ligand_matrix.shape[1]):
                 if method == "gmean":
                     receptor_matrix = (
-                        gmean((adata[nw["neighbors"][i], lr_network["to"]].X.A.T + 1) * weight[i, :], axis=1)
+                        gmean((adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T + 1) * weight[i, :], axis=1)
                         if x_sparse
                         else gmean((adata[nw["neighbors"][i], lr_network["to"]].X.T + 1) * weight[i, :], axis=1)
                     )
                 elif method == "mean":
                     receptor_matrix = (
-                        np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.A.T * weight[i, :], axis=1)
+                        np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T * weight[i, :], axis=1)
                         if x_sparse
                         else np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.T * weight[i, :], axis=1)
                     )
                 else:
                     receptor_matrix = (
-                        np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.A.T * weight[i, :], axis=1)
+                        np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T * weight[i, :], axis=1)
                         if x_sparse
                         else np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.T * weight[i, :], axis=1)
                     )
@@ -184,19 +184,19 @@ def niches(
             for i in range(ligand_matrix.shape[1]):
                 if method == "gmean":
                     receptor_matrix = (
-                        gmean((adata[nw["neighbors"][i], lr_network["to"]].X.A.T + 1), axis=1)
+                        gmean((adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T + 1), axis=1)
                         if x_sparse
                         else gmean((adata[nw["neighbors"][i], lr_network["to"]].X.T + 1), axis=1)
                     )
                 elif method == "mean":
                     receptor_matrix = (
-                        np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.A.T, axis=1)
+                        np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T, axis=1)
                         if x_sparse
                         else np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.T, axis=1)
                     )
                 else:
                     receptor_matrix = (
-                        np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.A.T, axis=1)
+                        np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T, axis=1)
                         if x_sparse
                         else np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.T, axis=1)
                     )
@@ -215,39 +215,39 @@ def niches(
             row, col = np.diag_indices_from(nw["weights"])
             nw["weights"][row, col] = 1
             weight = np.zeros(shape=(adata.n_obs, k))
-            for i, row in enumerate(nw["weights"].A):
+            for i, row in enumerate(nw["weights"].toarray()):
                 weight[i, :] = 1 / row[nw["neighbors"][i]]
             for i in range(ligand_matrix.shape[1]):
                 if method == "gmean":
                     receptor_matrix = (
-                        gmean((adata[nw["neighbors"][i], lr_network["to"]].X.A.T + 1) * weight[i, :], axis=1)
+                        gmean((adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T + 1) * weight[i, :], axis=1)
                         if x_sparse
                         else gmean((adata[nw["neighbors"][i], lr_network["to"]].X.T + 1) * weight[i, :], axis=1)
                     )
                     ligand_matrix = (
-                        gmean((adata[nw["neighbors"][i], lr_network["from"]].X.A.T + 1) * weight[i, :], axis=1)
+                        gmean((adata[nw["neighbors"][i], lr_network["from"]].X.toarray().T + 1) * weight[i, :], axis=1)
                         if x_sparse
                         else gmean((adata[nw["neighbors"][i], lr_network["from"]].X.T + 1) * weight[i, :], axis=1)
                     )
                 elif method == "mean":
                     receptor_matrix = (
-                        np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.A.T * weight[i, :], axis=1)
+                        np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T * weight[i, :], axis=1)
                         if x_sparse
                         else np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.T * weight[i, :], axis=1)
                     )
                     ligand_matrix = (
-                        np.mean(adata[nw["neighbors"][i], lr_network["from"]].X.A.T * weight[i, :], axis=1)
+                        np.mean(adata[nw["neighbors"][i], lr_network["from"]].X.toarray().T * weight[i, :], axis=1)
                         if x_sparse
                         else np.mean(adata[nw["neighbors"][i], lr_network["from"]].X.T * weight[i, :], axis=1)
                     )
                 else:
                     receptor_matrix = (
-                        np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.A.T * weight[i, :], axis=1)
+                        np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T * weight[i, :], axis=1)
                         if x_sparse
                         else np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.T * weight[i, :], axis=1)
                     )
                     ligand_matrix = (
-                        np.sum(adata[nw["neighbors"][i], lr_network["from"]].X.A.T * weight[i, :], axis=1)
+                        np.sum(adata[nw["neighbors"][i], lr_network["from"]].X.toarray().T * weight[i, :], axis=1)
                         if x_sparse
                         else np.sum(adata[nw["neighbors"][i], lr_network["from"]].X.T * weight[i, :], axis=1)
                     )
@@ -258,34 +258,34 @@ def niches(
             for i in range(ligand_matrix.shape[1]):
                 if method == "gmean":
                     receptor_matrix = (
-                        gmean((adata[nw["neighbors"][i], lr_network["to"]].X.A.T + 1), axis=1)
+                        gmean((adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T + 1), axis=1)
                         if x_sparse
                         else gmean((adata[nw["neighbors"][i], lr_network["to"]].X.T + 1), axis=1)
                     )
                     ligand_matrix = (
-                        gmean((adata[nw["neighbors"][i], lr_network["from"]].X.A.T + 1), axis=1)
+                        gmean((adata[nw["neighbors"][i], lr_network["from"]].X.toarray().T + 1), axis=1)
                         if x_sparse
                         else gmean((adata[nw["neighbors"][i], lr_network["from"]].X.T + 1), axis=1)
                     )
                 elif method == "mean":
                     receptor_matrix = (
-                        np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.A.T, axis=1)
+                        np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T, axis=1)
                         if x_sparse
                         else np.mean(adata[nw["neighbors"][i], lr_network["to"]].X.T, axis=1)
                     )
                     ligand_matrix = (
-                        np.mean(adata[nw["neighbors"][i], lr_network["from"]].X.A.T, axis=1)
+                        np.mean(adata[nw["neighbors"][i], lr_network["from"]].X.toarray().T, axis=1)
                         if x_sparse
                         else np.mean(adata[nw["neighbors"][i], lr_network["from"]].X.T, axis=1)
                     )
                 else:
                     receptor_matrix = (
-                        np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.A.T, axis=1)
+                        np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.toarray().T, axis=1)
                         if x_sparse
                         else np.sum(adata[nw["neighbors"][i], lr_network["to"]].X.T, axis=1)
                     )
                     ligand_matrix = (
-                        np.sum(adata[nw["neighbors"][i], lr_network["from"]].X.A.T, axis=1)
+                        np.sum(adata[nw["neighbors"][i], lr_network["from"]].X.toarray().T, axis=1)
                         if x_sparse
                         else np.sum(adata[nw["neighbors"][i], lr_network["from"]].X.T, axis=1)
                     )
@@ -355,10 +355,10 @@ def predict_ligand_activities(
 
     # Define expressed genes in sender and receiver cell populations(pct>0.1)
     expressed_genes_sender = np.array(adata.var_names)[
-        np.count_nonzero(adata[sender_cells, :].X.A, axis=0) / len(sender_cells) > 0.01
+        np.count_nonzero(adata[sender_cells, :].X.toarray(), axis=0) / len(sender_cells) > 0.01
     ].tolist()
     expressed_genes_receiver = np.array(adata.var_names)[
-        np.count_nonzero(adata[receiver_cells, :].X.A, axis=0) / len(receiver_cells) > 0.01
+        np.count_nonzero(adata[receiver_cells, :].X.toarray(), axis=0) / len(receiver_cells) > 0.01
     ].tolist()
 
     # Define a set of potential ligands
@@ -380,7 +380,7 @@ def predict_ligand_activities(
         response_expressed_genes = list(set(expressed_genes_receiver) & set(ligand_target_matrix.index))
         response_expressed_genes_df = pd.DataFrame(response_expressed_genes)
         response_expressed_genes_df = response_expressed_genes_df.rename(columns={0: "gene"})
-        response_expressed_genes_df["avg_expr"] = np.mean(adata[receiver_cells, response_expressed_genes].X.A, axis=0)
+        response_expressed_genes_df["avg_expr"] = np.mean(adata[receiver_cells, response_expressed_genes].X.toarray(), axis=0)
         lt_matrix = ligand_target_matrix[potential_ligands.tolist()].loc[response_expressed_genes_df["gene"].tolist()]
         de = []
         for ligand in lt_matrix:
@@ -482,7 +482,7 @@ def predict_target_genes(
         top_n_score = ligand_target_matrix[ligand].sort_values(ascending=False)[:top_target]
         if geneset is None:
             expressed_genes_receiver = np.array(adata.var_names)[
-                np.count_nonzero(adata[receiver_cells, :].X.A, axis=0) / len(receiver_cells) > 0.01
+                np.count_nonzero(adata[receiver_cells, :].X.toarray(), axis=0) / len(receiver_cells) > 0.01
             ].tolist()
             response_expressed_genes = list(set(expressed_genes_receiver) & set(ligand_target_matrix.index))
             targets = list(set(top_n_score.index) & set(response_expressed_genes))

--- a/spateo/tools/cluster/spagcn_utils.py
+++ b/spateo/tools/cluster/spagcn_utils.py
@@ -511,8 +511,8 @@ class SpaGCN(object):
         assert adata.shape[0] == adj.shape[0] == adj.shape[1]
         pca = PCA(n_components=self.num_pcs)
         if issparse(adata.X):
-            pca.fit(adata.X.A)
-            embed = pca.transform(adata.X.A)
+            pca.fit(adata.X.toarray())
+            embed = pca.transform(adata.X.toarray())
         else:
             pca.fit(adata.X)
             embed = pca.transform(adata.X)

--- a/spateo/tools/cluster_degs.py
+++ b/spateo/tools/cluster_degs.py
@@ -208,7 +208,7 @@ def find_cluster_degs(
 
     de = []
     for i_gene, gene in tqdm(enumerate(genes), desc="identifying top markers for each group"):
-        all_vals = X_data[:, i_gene].A if sparse else X_data[:, i_gene]
+        all_vals = X_data[:, i_gene].toarray() if sparse else X_data[:, i_gene]
         all_vals = all_vals.reshape(-1)
         test_vals = all_vals[test_cells]
         control_vals = all_vals[control_cells]

--- a/spateo/tools/find_neighbors.py
+++ b/spateo/tools/find_neighbors.py
@@ -112,13 +112,13 @@ def adj_to_knn(adj: np.ndarray, n_neighbors: int = 15) -> Tuple[np.ndarray, np.n
         current_n_neighbors = len(current_neighbors[1])
 
         if current_n_neighbors > n_neighbors - 1:
-            sorted_indices = np.argsort(adj[i][:, current_neighbors[1]].A)[0][: (n_neighbors - 1)]
+            sorted_indices = np.argsort(adj[i][:, current_neighbors[1]].toarray())[0][: (n_neighbors - 1)]
             indices[i, 1:] = current_neighbors[1][sorted_indices]
-            weights[i, 1:] = adj[i][0, current_neighbors[1][sorted_indices]].A
+            weights[i, 1:] = adj[i][0, current_neighbors[1][sorted_indices]].toarray()
         else:
             idx_ = np.arange(1, (current_n_neighbors + 1))
             indices[i, idx_] = current_neighbors[1]
-            weights[i, idx_] = adj[i][:, current_neighbors[1]].A
+            weights[i, idx_] = adj[i][:, current_neighbors[1]].toarray()
 
     return indices, weights
 

--- a/spateo/tools/glm.py
+++ b/spateo/tools/glm.py
@@ -93,7 +93,7 @@ def glm_degs(
         range(len(genes)), progress_name="Detecting genes via Generalized Additive Models (GAMs)"
     ):
         gene = genes[i]
-        expression = X_data[:, i].A if sparse else X_data[:, i]
+        expression = X_data[:, i].toarray() if sparse else X_data[:, i]
         df_factors["expression"] = expression
         try:
             nb2_full, nb2_null = glm_test(df_factors, fullModelFormulaStr, reducedModelFormulaStr)

--- a/spateo/tools/lisa.py
+++ b/spateo/tools/lisa.py
@@ -54,9 +54,9 @@ def lisa_geo_df(
     df = pd.DataFrame(coords, columns=["x", "y"])
 
     if layer is None:
-        df["exp"] = adata[:, gene].X.A.flatten()
+        df["exp"] = adata[:, gene].X.toarray().flatten()
     else:
-        df["exp"] = np.log1p(adata[:, gene].layers[layer].A.flatten())
+        df["exp"] = np.log1p(adata[:, gene].layers[layer].toarray().flatten())
 
     df["w_exp"] = weights.spatial_lag.lag_spatial(w, df["exp"])
     df["exp_zscore"] = (df["exp"] - df["exp"].mean()) / df["exp"].std()
@@ -200,9 +200,9 @@ def local_moran_i(
         diamond_spec,
     ):
         if layer is None:
-            db["exp"] = adata[:, cur_g].X.A.flatten()
+            db["exp"] = adata[:, cur_g].X.toarray().flatten()
         else:
-            db["exp"] = np.log1p(adata[:, cur_g].layers[layer].A.flatten())
+            db["exp"] = np.log1p(adata[:, cur_g].layers[layer].toarray().flatten())
 
         db["w_exp"] = weights.spatial_lag.lag_spatial(w, db["exp"])
 
@@ -424,9 +424,9 @@ def GM_lag_model(
         knn,
     ):
         if layer is None:
-            X["log_exp"] = adata[:, cur_g].X.A
+            X["log_exp"] = adata[:, cur_g].X.toarray()
         else:
-            X["log_exp"] = np.log1p(adata[:, cur_g].layers[layer].A)
+            X["log_exp"] = np.log1p(adata[:, cur_g].layers[layer].toarray())
 
         try:
             model = spreg.GM_Lag(

--- a/spateo/tools/spatial_degs.py
+++ b/spateo/tools/spatial_degs.py
@@ -106,7 +106,7 @@ def moran_i(
 
     # computing the moran_i for a single gene, and then used the joblib.Parallel to compute all genes in adata object.
     def _single(gene, X_data, W, adata, permutations):
-        cur_X = X_data[:, adata.var.index == gene].A if issparse(X_data) else X_data[:, adata.var.index == gene]
+        cur_X = X_data[:, adata.var.index == gene].toarray() if issparse(X_data) else X_data[:, adata.var.index == gene]
         mbi = explore.esda.moran.Moran(cur_X, W, permutations=permutations, two_tailed=False)
         Moran_I = mbi.I
         p_value = mbi.p_sim

--- a/spateo/tools/spatial_smooth.py
+++ b/spateo/tools/spatial_smooth.py
@@ -147,7 +147,7 @@ def smooth(
     # Original nonzero entries and values (keep these around):
     initial_nz_rows, initial_nz_cols = X.nonzero()
     if scipy.sparse.isspmatrix_csr(X):
-        initial_nz_vals = X[initial_nz_rows, initial_nz_cols].A1
+        initial_nz_vals = X[initial_nz_rows, initial_nz_cols].toarray().flatten()
     else:
         initial_nz_vals = X[initial_nz_rows, initial_nz_cols]
 

--- a/spateo/tools/utils.py
+++ b/spateo/tools/utils.py
@@ -60,7 +60,7 @@ def flatten(arr):
     if type(arr) == pd.core.series.Series:
         ret = arr.values.flatten()
     elif sp.issparse(arr):
-        ret = arr.A.flatten()
+        ret = arr.toarray().flatten()
     else:
         ret = arr.flatten()
     return ret


### PR DESCRIPTION
Replace `.A` with `toarray()` since SciPy deprecates `.A/.H` in the latest version.