### PR TITLE
Optimize function calling in `paste_pairwise_align`

### DIFF
--- a/spateo/alignment/methods/paste.py
+++ b/spateo/alignment/methods/paste.py
@@ -116,7 +116,7 @@ def paste_pairwise_align(
     except ImportError:
         from ot.gromov import cg
 
-    pi, log = ot.gromov.cg(
+    pi, log = ot.cg(
         a,
         b,
         (1 - alpha) * M,


### PR DESCRIPTION
Fixed this [issue](https://github.com/aristoteleo/spateo-release/issues/232).