### PR TITLE
Fix the bugs for paste align: add paste_align_preprocess back

### DIFF
--- a/spateo/alignment/methods/__init__.py
+++ b/spateo/alignment/methods/__init__.py
@@ -2,6 +2,7 @@
 # from .morpho_sparse import BA_align_sparse
 from .backend import NumpyBackend, TorchBackend
 from .deprecated_utils import (
+    paste_align_preprocess,
     align_preprocess,
     cal_dist,
     cal_dot,

--- a/spateo/alignment/methods/backend.py
+++ b/spateo/alignment/methods/backend.py
@@ -1067,7 +1067,7 @@ class NumpyBackend(Backend):
         else:
             return np.asarray(a, dtype=type_as.dtype)
 
-    def unique(self, a, return_index, return_inverse=False, axis=None):
+    def unique(self, a, return_index=False, return_inverse=False, axis=None):
         return np.unique(a, return_index=return_index, return_inverse=return_inverse, axis=axis)
 
     def unsqueeze(self, a, axis=-1):

--- a/spateo/alignment/methods/paste.py
+++ b/spateo/alignment/methods/paste.py
@@ -9,6 +9,7 @@ from sklearn.decomposition import NMF
 from spateo.logging import logger_manager as lm
 
 from .deprecated_utils import (
+    paste_align_preprocess,
     align_preprocess,
     calc_exp_dissimilarity,
     check_exp,
@@ -70,7 +71,7 @@ def paste_pairwise_align(
     """
 
     # Preprocessing
-    (nx, type_as, new_samples, exp_matrices, spatial_coords, normalize_scale, normalize_mean_list,) = align_preprocess(
+    (nx, type_as, new_samples, exp_matrices, spatial_coords, normalize_scale, normalize_mean_list,) = paste_align_preprocess(
         samples=[sampleA, sampleB],
         genes=genes,
         spatial_key=spatial_key,
@@ -116,7 +117,7 @@ def paste_pairwise_align(
     except ImportError:
         from ot.gromov import cg
 
-    pi, log = ot.gromov.cg(
+    pi, log = cg(
         a,
         b,
         (1 - alpha) * M,


### PR DESCRIPTION
## Fix bugs in paste alignment

### Motivation
Fixes an issue where `paste_align` would crash due to the incorrect use of the `align_preprocess` function (Closes #341).

### What’s Changed
- Restored the `paste_align_preprocess` function, which had previously been removed when introducing the new `align_preprocess`.
- Added a default value for `return_index` in the `NumpyBackend.unique()` function.
- Fixed a bug where `paste_align` failed to call the correct `cg` function because of API changes in different versions of the POT package.

### Validation
- Verified functionality of `st.align.paste_align`.

### Impact
Backward compatible, no API changes.