### PR TITLE
Fix installation/dependency issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.12'
           architecture: x64
       - name: Install dependencies
         run: make install-dev
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: [3.8, 3.9]
+        python: [3.9, 3.10, 3.11, 3.12]
         os: [ubuntu-22.04]
     name: Test on Python ${{ matrix.python }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: [3.9, 3.10, 3.11, 3.12]
+        python: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-22.04]
     name: Test on Python ${{ matrix.python }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install-all: install-dev install-docs install
 
 test:
 	rm -f .coverage
-	nosetests --verbose --with-coverage --cover-package spateo \
+	pytest --verbose --cov=spateo \
 		tests/* \
 		tests/io/* \
 		tests/preprocessing/* \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,9 +3,10 @@ bumpversion>=0.6.0
 coverage>=5.1
 cython>=0.29.10
 isort==5.10.1
-nose>=1.3.7
 numpy>=1.18.1
 pre-commit>=2.4.0
+pytest>=7
+pytest-cov>=4
 setuptools>=42
 sphinx>=3.3.1
 sphinx-autoapi>=1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 adjustText
-anndata>=0.8.0
+anndata>=0.8.0,<0.10.0; python_version < "3.11"
+anndata>=0.10.0; python_version >= "3.11"
 colorcet>=2.0.1
 # cvxopt>=1.2.3
 csbdeep>=0.6.3
@@ -19,10 +20,12 @@ nbconvert
 networkx>=2.6.3
 # ngs_tools>=1.6.0
 numba>=0.46.0
-numpy>=1.18.1
+numpy>=1.18.1,<=1.23.5; python_version < "3.11"
+numpy>=1.26,<2.0; python_version >= "3.11"
 opencv-python>=4.5.4.60
 # pandana
-pandas>=0.25.1
+pandas>=0.25.1,<=1.5.3; python_version < "3.11"
+pandas>=2.1,<3.0; python_version >= "3.11"
 # paste-bio>=1.4.0
 plotly>=5.1.0
 POT>=0.8.1
@@ -32,12 +35,14 @@ pysal>=1.14.4
 pyro-ppl
 python-igraph>=0.7.1
 pyvista>=0.39.1
-scipy>=1.0
+scipy>=1.0,<1.11; python_version < "3.11"
+scipy>=1.11,<1.14; python_version >= "3.11"
 scikit-image>=0.18.0
 scikit-learn>=0.19.1
 seaborn>=0.9.0
-setuptools>=58.0.4
-Shapely>=1.8.0
+setuptools>=58.0.4,<81
+Shapely>=1.8.0,<2.0; python_version < "3.11"
+Shapely>=2.0,<3.0; python_version >= "3.11"
 statsmodels>=0.9.0
 # tensorflow
 tqdm>=4.62.3
@@ -47,3 +52,5 @@ trame-server>=2.7.0
 typing_extensions>=4.0.1
 umap-learn>=0.5.1
 vtk>=9.2.2
+h5py>=3.7.0,<3.9.0; python_version < "3.11"
+h5py>=3.10.0; python_version >= "3.11"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 def read_requirements(path):
     with open(path, "r") as f:
-        return [line.strip() for line in f if not line.isspace()]
+        return [line.strip() for line in f if line.strip() and not line.lstrip().startswith("#")]
 
 
 with open("README.md", "r", encoding="UTF-8") as fh:
@@ -14,7 +14,6 @@ with open("README.md", "r", encoding="UTF-8") as fh:
 setup(
     name="spateo-release",
     version="1.1.1",
-    python_requires=">=3.7",
     install_requires=read_requirements("requirements.txt"),
     extras_require={
         "dev": read_requirements("dev-requirements.txt"),
@@ -24,10 +23,11 @@ setup(
     packages=find_packages(exclude=("tests", "docs")),
     classifiers=[
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering :: Bio-Informatics",

--- a/spateo/data_io.py
+++ b/spateo/data_io.py
@@ -1,14 +1,14 @@
-from anndata import (
-    AnnData,
-    concat,
-    read,
-    read_csv,
-    read_excel,
-    read_h5ad,
-    read_hdf,
-    read_loom,
-    read_mtx,
-    read_text,
-    read_umi_tools,
-    read_zarr,
-)
+from anndata import AnnData, concat, read_h5ad
+
+try:
+    # anndata < 0.12
+    from anndata import read
+except ImportError:
+    # anndata >= 0.12 removed `read`
+    read = read_h5ad
+
+try:
+    # anndata < 0.12 export these at top-level
+    from anndata import read_csv, read_excel, read_hdf, read_loom, read_mtx, read_text, read_umi_tools, read_zarr
+except ImportError:
+    from anndata.io import read_csv, read_excel, read_hdf, read_loom, read_mtx, read_text, read_umi_tools, read_zarr

--- a/spateo/data_io.py
+++ b/spateo/data_io.py
@@ -9,6 +9,24 @@ except ImportError:
 
 try:
     # anndata < 0.12 export these at top-level
-    from anndata import read_csv, read_excel, read_hdf, read_loom, read_mtx, read_text, read_umi_tools, read_zarr
+    from anndata import (
+        read_csv,
+        read_excel,
+        read_hdf,
+        read_loom,
+        read_mtx,
+        read_text,
+        read_umi_tools,
+        read_zarr,
+    )
 except ImportError:
-    from anndata.io import read_csv, read_excel, read_hdf, read_loom, read_mtx, read_text, read_umi_tools, read_zarr
+    from anndata.io import (
+        read_csv,
+        read_excel,
+        read_hdf,
+        read_loom,
+        read_mtx,
+        read_text,
+        read_umi_tools,
+        read_zarr,
+    )

--- a/spateo/plotting/static/three_d_plot/align_plots.py
+++ b/spateo/plotting/static/three_d_plot/align_plots.py
@@ -9,16 +9,21 @@ import numpy as np
 from anndata import AnnData
 from pyvista import PolyData
 
-from spateo.tdr import (
-    add_model_labels,
-    center_to_zero,
-    collect_models,
-    construct_pc,
-    merge_models,
-    translate_model,
-)
-
 from .three_dims_plots import three_d_multi_plot
+
+
+def _load_tdr_model():
+    """Load tdr model utilities lazily to avoid circular imports during package initialization."""
+    from ....tdr.models import (
+        add_model_labels,
+        center_to_zero,
+        collect_models,
+        construct_pc,
+        merge_models,
+        translate_model,
+    )
+
+    return add_model_labels, center_to_zero, collect_models, construct_pc, merge_models, translate_model
 
 
 def _check_cpos_in_multi_plot(
@@ -150,6 +155,7 @@ def multi_models(
     """
     adata_list = adata[0]
     adata_list = adata_list if isinstance(adata_list, list) else [adata_list]
+    add_model_labels, center_to_zero, collect_models, construct_pc, merge_models, _ = _load_tdr_model()
 
     # Construct a point cloud model
     pcs, ids, keys, cmaps = [], [], [], []
@@ -333,6 +339,8 @@ def deformation(
     text_kwargs: Optional[dict] = None,
     **kwargs,
 ):
+    add_model_labels, center_to_zero, collect_models, construct_pc, _, translate_model = _load_tdr_model()
+
     adata_list = adata[0]
     adata_list = adata_list if isinstance(adata_list, list) else [adata_list]
 

--- a/spateo/plotting/static/three_d_plot/three_dims_plots.py
+++ b/spateo/plotting/static/three_d_plot/three_dims_plots.py
@@ -15,8 +15,6 @@ try:
 except ImportError:
     from typing_extensions import Literal
 
-from spateo.tdr import collect_models
-
 from ..colorlabel import vega_10
 from .three_dims_plotter import (
     _set_jupyter,
@@ -457,6 +455,9 @@ def three_d_multi_plot(
                 * Output an obj file, please enter a filename ending with ``.obj``.
                 * Output a vtkjs file, please enter a filename without format.
     """
+
+    from ....tdr.models import collect_models
+
     models = model if isinstance(model, (MultiBlock, list)) else [model]
     keys = key if isinstance(key, list) else [key]
     cpos = cpo if isinstance(cpo, list) else [cpo]
@@ -689,6 +690,8 @@ def three_d_animate(
                 * Output an obj file, please enter a filename ending with ``.obj``.
                 * Output a vtkjs file, please enter a filename without format.
     """
+
+    from ....tdr.models import collect_models
 
     plotter_kws = dict(
         jupyter=False if jupyter is False else True,

--- a/spateo/tdr/interpolations/utils.py
+++ b/spateo/tdr/interpolations/utils.py
@@ -4,7 +4,6 @@ import numpy as np
 from anndata import AnnData
 
 from ...logging import logger_manager as lm
-from ...tools.utils import in_hull, polyhull
 
 
 def get_X_Y_grid(
@@ -32,6 +31,7 @@ def get_X_Y_grid(
             the input data points.
     """
     lm.main_info("Learn a continuous mapping from space to gene expression pattern")
+    from ...tools.utils import in_hull, polyhull
 
     X, Y = adata.obsm["spatial"] if X is None else X, adata[:, genes].X if Y is None else Y
 

--- a/spateo/tdr/models/models_migration/morphopath_model.py
+++ b/spateo/tdr/models/models_migration/morphopath_model.py
@@ -166,6 +166,7 @@ def construct_trajectory_X(
     trajectory_color: Union[str, list, dict] = "gainsboro",
     tip_color: Union[str, list, dict] = "orangered",
     alpha: Union[float, list, dict] = 1.0,
+    return_merged: bool = True,
 ) -> Tuple[Any, Optional[str]]:
     """
     Reconstruction of cell developmental trajectory model.
@@ -267,7 +268,7 @@ def construct_trajectory_X(
         alpha=alpha,
     )
 
-    trajectory_model = merge_models([streamlines, arrows])
+    trajectory_model = merge_models([streamlines, arrows]) if return_merged else [streamlines, arrows]
     return trajectory_model, plot_cmap
 
 
@@ -283,6 +284,7 @@ def construct_trajectory(
     trajectory_color: Union[str, list, dict] = "gainsboro",
     tip_color: Union[str, list, dict] = "orangered",
     alpha: float = 1.0,
+    return_merged: bool = True,
 ) -> Tuple[Any, Optional[str]]:
     """
     Reconstruction of cell developmental trajectory model based on cell fate prediction.
@@ -331,6 +333,7 @@ def construct_trajectory(
         trajectory_color=trajectory_color,
         tip_color=tip_color,
         alpha=alpha,
+        return_merged=return_merged,
     )
 
     return trajectory_model, plot_cmap

--- a/spateo/tdr/morphometrics/morphofield/sparsevfc.py
+++ b/spateo/tdr/morphometrics/morphofield/sparsevfc.py
@@ -9,8 +9,8 @@ import numpy as np
 import pandas as pd
 from anndata import AnnData
 
-from spateo.alignment import get_optimal_mapping_relationship
 from spateo.alignment.methods import paste_pairwise_align
+from spateo.alignment.utils import get_optimal_mapping_relationship
 from spateo.logging import logger_manager as lm
 from spateo.tdr.interpolations import get_X_Y_grid
 


### PR DESCRIPTION
## Summary
This PR focuses on installation compatibility and import stability, especially for Python 3.9–3.12 and newer `anndata` versions.

## What Changed
- Updated dependency constraints in `requirements.txt` with Python-version markers:
  - `anndata`, `numpy`, `pandas`, `scipy`, `Shapely`, `h5py`, `setuptools`.
- Improved `setup.py` requirements parsing:
  - Ignore empty/comment lines when loading requirements.
  - Updated classifiers to include Python 3.11/3.12 and removed outdated 3.7 classifier.
- Added compatibility handling for `anndata` API changes in `spateo/data_io.py`:
  - Fallback imports for `read*` functions between older and newer `anndata` versions.
- Reduced circular import risk by moving heavy imports to lazy/runtime import:
  - `spateo/plotting/static/three_d_plot/align_plots.py`
  - `spateo/plotting/static/three_d_plot/three_dims_plots.py`
  - `spateo/tdr/interpolations/utils.py`
- Fixed import path for alignment utility:
  - `get_optimal_mapping_relationship` now imported from `spateo.alignment.utils`.
- Added optional behavior for trajectory model output in morphopath:
  - New parameter `return_merged` in `construct_trajectory_X` and `construct_trajectory` (default `True` to keep existing behavior).

## Why
- Resolve installation issues across Python versions.
- Handle upstream library API changes (`anndata`) without breaking existing workflows.
- Avoid circular-import related initialization/runtime failures.
- Provide more flexible trajectory model output format for downstream usage.

## Backward Compatibility
- Default behavior remains unchanged (`return_merged=True`).
- Existing call sites should continue to work without modification.

## Validation
Local install checks passed in fresh conda envs:
- Python 3.9 / 3.10 / 3.11 / 3.12
- `pip install .` succeeded
- `pip check` succeeded
- `import spateo` succeeded
